### PR TITLE
Add OnLeftRoom Event to RoomClient

### DIFF
--- a/Documentation/docs/leavingandjoiningrooms.md
+++ b/Documentation/docs/leavingandjoiningrooms.md
@@ -1,0 +1,25 @@
+# Leaving and Joining
+
+When a `RoomClient` starts it is automatically a member of an empty, unidentified, room.
+
+A `RoomClient` can create a new room or join an existing one at any time. Joining or leaving a room involes a *room change*. Changing the room is the same whether the client is going to or from an empty room, or between non-empty rooms.
+
+When the room changes `RoomClient` will emit a number of events in order:
+
+1. `OnLeftRoom` with the old room
+2. `OnPeerRemoved` for any peers that are not in the new room
+3. `OnJoinedRoom` with the new room
+4. `OnRoom` with the new room
+5. `OnPeer` for all updated peers
+
+As usual, `OnPeer` and `OnRoom` may be called even if there is no change in the `PeerInfo` or `RoomInfo`.
+
+## Synchronising Peers
+
+Two peers attempting to join a room at the same time could result in a race condition. This is resolved at the server: when a peer joins a room, it receives a list of all other peers in the room. This list is always sent before the next peer joins.
+
+When `OnJoinedRoom` is emitted, `RoomClient::Peers` will contain the existing peers in the room exactly, no more and no less.
+
+This event can be used to distinguish then between 'old' or 'existing' and 'new' peers. Any peer that was in `RoomClient::Peers` when `OnJoinedRoom` was called, joined the room before `RoomClient`, and any peer that was not in `RoomClient::Peers` joined the room after.
+
+For example, this is used by the audio chat manager to decide which peer will start the process of creating an audio channel, without those peers having to explicitly communicate, using only the rule that new peers must make the connection to existing ones.

--- a/Documentation/mkdocs.yml
+++ b/Documentation/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
             - Introduction: serverintroduction.md
             - Server Overview: serveroverview.md
             - Heartbeat: serverheartbeat.md
+            - Leaving and Joining: leavingandjoiningrooms.md
     - Programming:
         - Async Design Patterns: asyncdesignpatterns.md
     - Development:

--- a/Node/rooms.js
+++ b/Node/rooms.js
@@ -90,6 +90,10 @@ class RoomServer{
         console.log(peer.uuid + " joined room " + room.uuid);
     }
 
+    async leave(peer){
+        peer.room.removePeer(peer);
+    }
+
     getPublishableRooms(){
         return {
             rooms: this.roomDatabase.all().filter(r => r.publish === true).map(r => r.getRoomArgs()),
@@ -287,6 +291,9 @@ class RoomPeer{
                         console.log(argsResult.instance);
                         console.log(argsResult.errors);
                     }
+                    break;
+                case "Leave":
+                    this.server.leave(this);
                     break;
                 case "UpdatePeer":
                     var argsResult = this.validator.validate(message.args,this.updatePeerArgsSchema);

--- a/Unity/Assets/Editor/Rooms/RoomClientEditor.cs
+++ b/Unity/Assets/Editor/Rooms/RoomClientEditor.cs
@@ -55,7 +55,7 @@ namespace Ubiq.Rooms
 
             managerReorderableList.DoLayoutList();
 
-            if(component.joinedRoom)
+            if(component.JoinedRoom)
             {
                 EditorGUILayout.HelpBox("Joined Room " + component.Room.UUID, MessageType.Info);
             }
@@ -84,6 +84,11 @@ namespace Ubiq.Rooms
             if(GUILayout.Button("Create Room")) // creates a room with a random id and joins it
             {
                 component.JoinNew($"Editor Room {IdGenerator.GenerateUnique().ToString()}", true); // publish true because we probably need other Editor inspectors to see it
+            }
+
+            if(GUILayout.Button("Leave Room"))
+            {
+                component.Leave();
             }
 
             if (GUILayout.Button("Refresh"))

--- a/Unity/Assets/Runtime/Avatars/AvatarManager.cs
+++ b/Unity/Assets/Runtime/Avatars/AvatarManager.cs
@@ -155,7 +155,7 @@ namespace Ubiq.Avatars
             }
         }
 
-        private void OnJoinedRoom()
+        private void OnJoinedRoom(RoomInfo room)
         {
             foreach (var item in client.Peers)
             {

--- a/Unity/Assets/Runtime/Rooms/RoomClient.cs
+++ b/Unity/Assets/Runtime/Rooms/RoomClient.cs
@@ -218,6 +218,10 @@ namespace Ubiq.Rooms
             {
                 OnRoomsAvailable = new RoomsAvailableEvent();
             }
+            if (OnRoom == null)
+            {
+                OnRoom = new RoomEvent();
+            }
             if (OnLeftRoom == null)
             {
                 OnLeftRoom = new RoomEvent();

--- a/Unity/Assets/Runtime/Rooms/RoomClient.cs
+++ b/Unity/Assets/Runtime/Rooms/RoomClient.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using UnityEngine.Events;
 using Ubiq.Dictionaries;
 using Ubiq.XR.Notifications;
+using System.Linq;
 
 namespace Ubiq.Rooms
 {
@@ -34,10 +35,10 @@ namespace Ubiq.Rooms
         public ConnectionDefinition[] servers;
 
         private Dictionary<string, Action<string>> blobCallbacks;
-        private float PingSent;
-        private float PingReceived;
-        private float HeartbeatReceived => Time.realtimeSinceStartup - PingReceived;
-        private float HeartbeatSent => Time.realtimeSinceStartup - PingSent;
+        private float pingSent;
+        private float pingReceived;
+        private float heartbeatReceived => Time.realtimeSinceStartup - pingReceived;
+        private float heartbeatSent => Time.realtimeSinceStartup - pingSent;
         public static float HeartbeatTimeout = 5f;
         public static float HeartbeatInterval = 1f;
 
@@ -54,7 +55,7 @@ namespace Ubiq.Rooms
             {
                 get
                 {
-                    return $"No Connection ({ client.HeartbeatReceived } seconds ago)";
+                    return $"No Connection ({ client.heartbeatReceived } seconds ago)";
                 }
             }
         }
@@ -71,25 +72,8 @@ namespace Ubiq.Rooms
             bool NeedsUpdate();
         }
 
-        /// <summary>
-        /// The RoomInterface class provides encapsulation for the RoomInfo data transfer object. It provides a single
-        /// reference that is safe to store, and prevents unsafe writes. All accesses to the RoomClient's current Room
-        /// should go through this.
-        /// </summary>
-        public class RoomInterface : IRoomInterfaceFriend
+        public class RoomInterfaceFriend : RoomInterface, IRoomInterfaceFriend
         {
-            public string Name { get; private set; }
-            public string UUID { get; private set; }
-            public string JoinCode { get; private set; }
-            public bool Publish { get; private set; }
-
-            private SerializableDictionary properties;
-
-            public RoomInterface()
-            {
-                properties = new SerializableDictionary();
-            }
-
             // The explicit implementation means the member will have the same visibility as the interface that declares it
             void IRoomInterfaceFriend.Update(RoomInfo args)
             {
@@ -112,23 +96,7 @@ namespace Ubiq.Rooms
                     return false;
                 }
             }
-
-            public string this[string key]
-            {
-                get => properties[key];
-                set => properties[key] = value;
-            }
-
-            public IEnumerable<KeyValuePair<string,string>> Properties
-            {
-                get => properties.Enumerator;
-            }
-
-            public RoomInfo GetRoomInfo()
-            {
-                return new RoomInfo(Name, UUID, JoinCode, Publish, properties);
-            }
-        }
+        }        
 
         private interface IPeerInterfaceFriend
         {
@@ -136,21 +104,11 @@ namespace Ubiq.Rooms
             bool NeedsUpdate();
         }
 
-        /// <summary>
-        /// The PeerInterface class provides encapsulation of the PeerInfo data transfer object, similar to the RoomInterface above.
-        /// </summary>
-        public class PeerInterface : IPeerInterfaceFriend
+        public class PeerInterfaceFriend : PeerInterface, IPeerInterfaceFriend
         {
-            public string UUID { get; private set; }
-
-            public PeerInterface(String uuid)
+            public PeerInterfaceFriend(string uuid):base(uuid)
             {
-                UUID = uuid;
-                properties = new SerializableDictionary();
             }
-
-            private SerializableDictionary properties;
-            private NetworkId networkId;
 
             void IPeerInterfaceFriend.SetNetworkContext(NetworkContext context)
             {
@@ -161,17 +119,6 @@ namespace Ubiq.Rooms
             {
                 return properties.IsUpdated();
             }
-
-            public string this[string key]
-            {
-                get => properties[key];
-                set => properties[key] = value;
-            }
-
-            public PeerInfo GetPeerInfo()
-            {
-                return new PeerInfo(UUID, networkId, properties);
-            }
         }
 
         public RoomInterface Room { get; private set; }
@@ -179,6 +126,7 @@ namespace Ubiq.Rooms
 
         public class RejectedEvent : UnityEvent<RejectedArgs> { };
         public class PeerEvent : UnityEvent<PeerInfo> { };
+        public class RoomEvent : UnityEvent<RoomInfo> { };
         public class RoomsAvailableEvent : UnityEvent<List<RoomInfo>> { };
 
         /// <summary>
@@ -194,7 +142,15 @@ namespace Ubiq.Rooms
         /// <summary>
         /// Emitted when this peer has joined a room
         /// </summary>
-        public UnityEvent OnJoinedRoom;
+        public RoomEvent OnJoinedRoom;
+
+        /// <summary>
+        /// Emitted when this peer has left a room
+        /// </summary>
+        /// <remarks>
+        /// This will always be emitted before a new room is joined (even if the client is not yet a member of a room - in which case the room will be empty)
+        /// </remarks>
+        public RoomEvent OnLeftRoom;
 
         /// <summary>
         /// Emitted when this peer attempts to join a room and is rejected
@@ -204,7 +160,7 @@ namespace Ubiq.Rooms
         /// <summary>
         /// Emitted when the room this peer is a member of has updated its properties
         /// </summary>
-        public UnityEvent OnRoom;
+        public RoomEvent OnRoom;
 
         /// <summary>
         /// Contains the latest list of rooms currently available on the server. Usually emitted in response to a discovery request.
@@ -232,11 +188,11 @@ namespace Ubiq.Rooms
             };
         }
 
-        public bool joinedRoom
+        public bool JoinedRoom
         {
             get
             {
-                return Room != null && Room.UUID != null && Room.UUID != "";
+                return Room != null && Room.UUID != null && Room.UUID != ""; // Null check because this may be called in the Editor
             }
         }
 
@@ -244,7 +200,7 @@ namespace Ubiq.Rooms
         {
             if (OnJoinedRoom == null)
             {
-                OnJoinedRoom = new UnityEvent();
+                OnJoinedRoom = new RoomEvent();
             }
             if (OnJoinRejected == null)
             {
@@ -262,17 +218,21 @@ namespace Ubiq.Rooms
             {
                 OnRoomsAvailable = new RoomsAvailableEvent();
             }
+            if (OnLeftRoom == null)
+            {
+                OnLeftRoom = new RoomEvent();
+            }
 
             blobCallbacks = new Dictionary<string, Action<string>>();
 
-            Room = new RoomInterface();
+            Room = new RoomInterfaceFriend();
             peers = new Dictionary<string, PeerInfo>();
             Available = new List<RoomInfo>();
 
-            OnJoinedRoom.AddListener(() => Debug.Log("Joined Room " + Room.Name));
+            OnJoinedRoom.AddListener((room) => Debug.Log("Joined Room " + room.Name));
             OnRoomsAvailable.AddListener((rooms) => Available = rooms);
 
-            Me = new PeerInterface(Guid.NewGuid().ToString());
+            Me = new PeerInterfaceFriend(Guid.NewGuid().ToString());
         }
 
         private void Start()
@@ -297,15 +257,40 @@ namespace Ubiq.Rooms
             {
                 case "Accepted":
                     {
+                        OnLeftRoom.Invoke(Room.GetRoomInfo());
+                        
                         var args = JsonUtility.FromJson<AcceptedArgs>(container.args);
                         (Room as IRoomInterfaceFriend).Update(args.room);
-                        peers.Clear();
+
+                        var newPeerGuids = args.peers.Select(x => x.UUID);
+                        var peersToRemove = new List<PeerInfo>();
+                        foreach (var item in peers)
+                        {
+                            if (!newPeerGuids.Contains(item.Key))
+                            {
+                                peersToRemove.Add(item.Value);
+                            }
+                        }
+
+                        foreach (var item in peersToRemove)
+                        {
+                            peers.Remove(item.UUID);
+                            OnPeerRemoved.Invoke(item);
+                        }
+
                         foreach (var item in args.peers)
                         {
                             peers[item.UUID] = item;
                         }
-                        OnJoinedRoom.Invoke();
-                        OnRoom.Invoke();
+
+                        var info = Room.GetRoomInfo();
+                        OnJoinedRoom.Invoke(info);
+                        OnRoom.Invoke(info);
+
+                        foreach (var item in peers.Values)
+                        {
+                            OnPeer.Invoke(item);
+                        }
                     }
                     break;
                 case "Rejected":
@@ -318,7 +303,7 @@ namespace Ubiq.Rooms
                     {
                         var args = JsonUtility.FromJson<RoomInfo>(container.args);
                         (Room as IRoomInterfaceFriend).Update(args);
-                        OnRoom.Invoke();
+                        OnRoom.Invoke(Room.GetRoomInfo());
                     }
                     break;
                 case "UpdatePeer":
@@ -358,7 +343,7 @@ namespace Ubiq.Rooms
                     break;
                 case "Ping":
                     {
-                        PingReceived = Time.realtimeSinceStartup;
+                        pingReceived = Time.realtimeSinceStartup;
                         PlayerNotifications.Delete(ref notification);
                     }
                     break;
@@ -385,6 +370,9 @@ namespace Ubiq.Rooms
             (Me as IPeerInterfaceFriend).NeedsUpdate(); // This will clear the updated needed flag
         }
 
+        /// <summary>
+        /// Joins an existing room using a join code.
+        /// </summary>
         public void Join(string joincode)
         {
             SendToServer("Join", new JoinArgs()
@@ -393,6 +381,17 @@ namespace Ubiq.Rooms
                 peer = Me.GetPeerInfo()
             });
             (Me as IPeerInterfaceFriend).NeedsUpdate();
+        }
+
+        /// <summary>
+        /// Leaves the current room
+        /// </summary>
+        /// <remarks>
+        /// Can be called even before a client joins a room, though OnLeftRoom is not guaranteed to be called if there was no existing room
+        /// </remarks>
+        public void Leave()
+        {
+            SendToServer("Leave", null);
         }
 
         public void Connect(ConnectionDefinition connection)
@@ -410,11 +409,11 @@ namespace Ubiq.Rooms
             {
                 SendToServer("UpdateRoom", Room.GetRoomInfo());
             }
-            if (HeartbeatSent > HeartbeatInterval)
+            if (heartbeatSent > HeartbeatInterval)
             {
                 Ping();
             }
-            if (HeartbeatReceived > HeartbeatTimeout)
+            if (heartbeatReceived > HeartbeatTimeout)
             {
                 if (notification == null)
                 {
@@ -477,7 +476,7 @@ namespace Ubiq.Rooms
 
         public void Ping()
         {
-            PingSent = Time.realtimeSinceStartup;
+            pingSent = Time.realtimeSinceStartup;
             SendToServer("Ping", null);
         }
     }

--- a/Unity/Assets/Runtime/WebRtc/WebRtcPeerConnectionManager.cs
+++ b/Unity/Assets/Runtime/WebRtc/WebRtcPeerConnectionManager.cs
@@ -78,13 +78,18 @@ namespace Ubiq.WebRtc
         // and existing peers to accept that connection.
         // This is because we need to know that the remote peer is established, before beginning the exchange of messages.
 
-        public void OnJoinedRoom()
+        public void OnJoinedRoom(RoomInfo room)
         {
             foreach (var peer in client.Peers)
             {
                 if (peer.UUID == client.Me.UUID)
                 {
-                    continue; // don't connect to ones self!
+                    continue; // Don't connect to ones self!
+                }
+
+                if(peerUUIDToConnection.ContainsKey(peer.UUID))
+                {
+                    continue; // This peer existed in the previous room and we already have a connection to it
                 }
 
                 var pcid = NetworkScene.GenerateUniqueId(); //A single audio channel exists between two peers. Each audio channel has its own Id.

--- a/Unity/Assets/Samples/Applications/Boids/BoidsManager.cs
+++ b/Unity/Assets/Samples/Applications/Boids/BoidsManager.cs
@@ -80,7 +80,7 @@ namespace Ubiq.Samples.Boids
             flock.local = local;
         }
 
-        private void OnJoinedRoom()
+        private void OnJoinedRoom(RoomInfo room)
         {
             foreach (var item in client.Peers)
             {

--- a/Unity/Assets/Samples/Introduction/Scripts/BrowsePanelController.cs
+++ b/Unity/Assets/Samples/Introduction/Scripts/BrowsePanelController.cs
@@ -39,7 +39,7 @@ namespace Ubiq.Samples
             return go.GetComponent<BrowseMenuControl>();
         }
 
-        private void RoomClient_OnJoinedRoom()
+        private void RoomClient_OnJoinedRoom(RoomInfo room)
         {
             UpdateAvailableRooms();
 
@@ -74,7 +74,7 @@ namespace Ubiq.Samples
             int controlI = 0;
             for (int roomI = 0; roomI < rooms.Count; controlI++,roomI++)
             {
-                if (mainMenu.roomClient.joinedRoom &&
+                if (mainMenu.roomClient.JoinedRoom &&
                     mainMenu.roomClient.Room.UUID == rooms[roomI].UUID)
                 {
                     joinedControl.gameObject.SetActive(true);

--- a/Unity/Assets/Samples/Introduction/Scripts/CurrentRoomPanel.cs
+++ b/Unity/Assets/Samples/Introduction/Scripts/CurrentRoomPanel.cs
@@ -37,7 +37,7 @@ namespace Ubiq.Samples
             }
         }
 
-        private void RoomClient_OnJoinedRoom()
+        private void RoomClient_OnJoinedRoom(RoomInfo room)
         {
             UpdateControl(true);
         }
@@ -49,7 +49,7 @@ namespace Ubiq.Samples
                 return;
             }
 
-            if (mainMenu.roomClient.joinedRoom)
+            if (mainMenu.roomClient.JoinedRoom)
             {
                 notInRoomPanel.SetActive(false);
                 inRoomPanel.SetActive(true);

--- a/Unity/Assets/Samples/Introduction/Scripts/JoincodeJoinButton.cs
+++ b/Unity/Assets/Samples/Introduction/Scripts/JoincodeJoinButton.cs
@@ -22,7 +22,7 @@ namespace Ubiq.Samples
             mainMenu.roomClient.OnJoinedRoom.RemoveListener(RoomClient_OnJoinedRoom);
         }
 
-        private void RoomClient_OnJoinedRoom()
+        private void RoomClient_OnJoinedRoom(RoomInfo room)
         {
             mainPanel.SwitchPanelToDefault();
         }

--- a/Unity/Assets/Samples/Introduction/Scripts/MainMenu.cs
+++ b/Unity/Assets/Samples/Introduction/Scripts/MainMenu.cs
@@ -110,7 +110,7 @@ namespace Ubiq.Samples
             gameObject.SetActive(true);
         }
 
-        private void RoomClient_OnJoinedRoom()
+        private void RoomClient_OnJoinedRoom(RoomInfo room)
         {
             if (roomClient != null &&
                 roomClient.Room != null &&

--- a/Unity/Assets/Samples/Introduction/Scripts/NetworkSpawner.cs
+++ b/Unity/Assets/Samples/Introduction/Scripts/NetworkSpawner.cs
@@ -99,9 +99,9 @@ namespace Ubiq.Samples
             return spawned;
         }
 
-        private void OnRoom()
+        private void OnRoom(RoomInfo room)
         {
-            foreach (var item in roomClient.Room.Properties)
+            foreach (var item in room.Properties)
             {
                 if(item.Key.StartsWith("SpawnedObject"))
                 {

--- a/Unity/Assets/Samples/Introduction/Scripts/RoomSceneManager.cs
+++ b/Unity/Assets/Samples/Introduction/Scripts/RoomSceneManager.cs
@@ -22,16 +22,16 @@ namespace Ubiq.Samples
             client.OnJoinedRoom.AddListener(OnJoinedRoom);
         }
 
-        private void OnJoinedRoom()
+        private void OnJoinedRoom(RoomInfo room)
         {
-            var name = client.Room["scene-name"];
+            var name = room["scene-name"];
             if(name == null)
             {
                 UpdateRoomScene(); // if we've joined a room without a scene
             }
         }
 
-        private void OnRoom()
+        private void OnRoom(RoomInfo room)
         {
             var name = client.Room["scene-name"];
             if (name != null)

--- a/Unity/Assets/Samples/Introduction/Scripts/RoomsMenuController.cs
+++ b/Unity/Assets/Samples/Introduction/Scripts/RoomsMenuController.cs
@@ -35,7 +35,7 @@ namespace Ubiq.Samples
             return go.GetComponent<RoomsMenuControl>();
         }
 
-        private void OnJoinedRoom()
+        private void OnJoinedRoom(RoomInfo room)
         {
             UpdateAvailableRooms();
 
@@ -62,7 +62,7 @@ namespace Ubiq.Samples
                 return;
             }
 
-            if (roomClient.joinedRoom) {    // Update joined room
+            if (roomClient.JoinedRoom) {    // Update joined room
                 if (joinedControl != null)
                 {
                     joinedControl.gameObject.SetActive(true);
@@ -73,7 +73,7 @@ namespace Ubiq.Samples
             int controlI = 0;
             for (int roomI = 0; roomI < rooms.Count; controlI++,roomI++)
             {
-                if (roomClient.joinedRoom &&
+                if (roomClient.JoinedRoom &&
                     roomClient.Room.UUID == rooms[roomI].UUID)
                 {
                     // Skip room we are currently in - handled elsewhere

--- a/Unity/Assets/Samples/Minimal/Rooms/Scripts/RoomClientJoinHelper.cs
+++ b/Unity/Assets/Samples/Minimal/Rooms/Scripts/RoomClientJoinHelper.cs
@@ -45,7 +45,7 @@ namespace Ubiq.Samples.Minimal.Rooms
 
             roomClients.Remove(primary);
 
-            primary.OnJoinedRoom.AddListener(() =>
+            primary.OnJoinedRoom.AddListener((RoomInfo room) =>
             {
                 foreach (var item in roomClients)
                 {


### PR DESCRIPTION
This PR adds a new event, OnLeftRoom, to RoomClient, and updates the events called on a room change. It also adds a new API, Leave, to RoomClient, to leave a room.