### PR TITLE
Fixed issue with VoipAvatar not correctly checking if it was destroyed

### DIFF
--- a/Unity/Assets/Runtime/Voip/VoipAvatar.cs
+++ b/Unity/Assets/Runtime/Voip/VoipAvatar.cs
@@ -31,7 +31,7 @@ namespace Ubiq.Avatars
         private void OnPeerConnection(VoipPeerConnection peerConnection)
         {
             // If we're very unlucky, this is called after we're destroyed
-            if (!enabled)
+            if (this == null || !enabled)
             {
                 return;
             }


### PR DESCRIPTION
When Unity destroy as GameObject `this` evaluates to `null` (at least in Unit version 2021.X) hence the check for `!enabled` throws an error.
Adding a simple null check circumvents this.