### PR TITLE
Adding an automatic reconnection process to RoomClient for recovery a…

### DIFF
--- a/Unity/Assets/Editor/Rooms/RoomClientEditor.cs
+++ b/Unity/Assets/Editor/Rooms/RoomClientEditor.cs
@@ -92,6 +92,8 @@ namespace Ubiq.Rooms
                 EditorGUILayout.HelpBox("Joined Room " + component.Room.UUID, MessageType.Info);
             }
 
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("reconnectBehaviour"));
+
             foldoutRooms = EditorGUILayout.BeginFoldoutHeaderGroup(foldoutRooms, "Available Rooms");
 
             if (foldoutRooms)

--- a/Unity/Assets/Runtime/Messaging/NetworkScene.cs
+++ b/Unity/Assets/Runtime/Messaging/NetworkScene.cs
@@ -250,7 +250,7 @@ namespace Ubiq.Messaging
         /// Public method instructing the network scene to drop all current connections and dispose of them.
         /// Used to recover from a connection loss to Nexus.
         /// </summary>
-        public void ResetConnections()
+        public void ClearConnections()
         {
             foreach (var c in connections)
             {
@@ -349,18 +349,7 @@ namespace Ubiq.Messaging
 
         private void OnDestroy()
         {
-            foreach (var c in connections)
-            {
-                try
-                {
-                    c.Dispose();
-                }
-                catch
-                {
-
-                }
-            }
-            connections.Clear();
+            ClearConnections();
         }
     }
 }

--- a/Unity/Assets/Runtime/Messaging/NetworkScene.cs
+++ b/Unity/Assets/Runtime/Messaging/NetworkScene.cs
@@ -246,6 +246,26 @@ namespace Ubiq.Messaging
             connections.Add(connection);
         }
 
+        /// <summary>
+        /// Public method instructing the network scene to drop all current connections and dispose of them.
+        /// Used to recover from a connection loss to Nexus.
+        /// </summary>
+        public void ResetConnections()
+        {
+            foreach (var c in connections)
+            {
+                try
+                {
+                    c.Dispose();
+                }
+                catch
+                {
+
+                }
+            }
+            connections.Clear();
+        }
+
         private void Update()
         {
             OnUpdate.Invoke();

--- a/Unity/Assets/Runtime/Rooms/RoomClient.cs
+++ b/Unity/Assets/Runtime/Rooms/RoomClient.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Codice.Client.Commands;
+using JetBrains.Annotations;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Ubiq.Dictionaries;
@@ -240,6 +242,20 @@ namespace Ubiq.Rooms
         private float heartbeatSent => Time.realtimeSinceStartup - pingSent;
         public static float HeartbeatTimeout = 5f;
         public static float HeartbeatInterval = 1f;
+
+        // Parameters private and public for the reconnection process.
+        private enum ReconnectionStatus { Off, Reset, Received, Rejoining};
+        private ReconnectionStatus reconnectionStatus = ReconnectionStatus.Off;
+        private float lastResetTime = 0;
+        private float timeSinceLastReset => Time.realtimeSinceStartup - lastResetTime;
+        private float lastRejoinTime = 0;
+        private float timeSinceLastRejoin => Time.realtimeSinceStartup - lastRejoinTime;
+        private Guid previousRoomGUID = Guid.Empty;
+        public static bool AttemtReconnecting = true; // Whether the RoomClient attemtps to reconnect to the server on connection loss.
+        public static float ReconnectTimeout = 5f; // How long a timeout can last until the reconnect procedure is triggered.
+        public static float ReconnectInterval = 5f; // The intervals in which reconnect attempts are done.
+        public static float RejoinInterval = 5f; // The intervals in which rejoin attempts are done.
+
         private PeerInterfaceFriend me = new PeerInterfaceFriend(Guid.NewGuid().ToString());
         private RoomInterfaceFriend room = new RoomInterfaceFriend();
         private NetworkScene scene;
@@ -547,6 +563,11 @@ namespace Ubiq.Rooms
                 case "Ping":
                     {
                         pingReceived = Time.realtimeSinceStartup;
+
+                        // Set flag for first ping after connection loss
+                        if (reconnectionStatus == ReconnectionStatus.Reset)
+                            reconnectionStatus = ReconnectionStatus.Received;
+
                         PlayerNotifications.Delete(ref notification);
                         var response = JsonUtility.FromJson<PingResponseArgs>(container.args);
                         OnPingResponse(response);
@@ -635,6 +656,38 @@ namespace Ubiq.Rooms
             scene.AddConnection(Connections.Resolve(connection));
         }
 
+        /// <summary>
+        /// Method to reset all current connections and reconnect to the ones defined by the user in the Unity UI.
+        /// </summary>
+        public void ResetAndReconnect()
+        {
+            ResetAndReconnect(servers);
+        }
+
+        /// <summary>
+        /// Method to reset all current connections and reconnect to the ones defined in the connection definition passed as argument.
+        /// </summary>
+        /// <param name="connectionDefinitions">The connection definition that will be connected after the reset.</param>
+        public void ResetAndReconnect(ConnectionDefinition[] connectionDefinitions)
+        {
+            // Drop all connections
+            scene.ResetConnections();
+
+            // Reconnect all connections
+            foreach (var item in connectionDefinitions)
+            {
+                try
+                {
+                    Connect(item);
+                }
+                catch(Exception e)
+                {
+                    Debug.LogError(e.ToString());
+                }
+            }
+        }
+
+
         private void Update()
         {
             actions.ForEach(a => a());
@@ -677,6 +730,52 @@ namespace Ubiq.Rooms
                 if (notification == null)
                 {
                     notification = PlayerNotifications.Show(new TimeoutNotification(this));
+                }
+            }
+
+            // Reconnection behaviour
+            // Test if dynamic reconnection is enabled
+            if(AttemtReconnecting)
+            {
+                // If enabled, check for current reconnection status
+                switch (reconnectionStatus)
+                {
+                    // Reconnection off: If reconnect timeout is exceeded, old room GUID is stored, reset initiated, and next state is initiaded.
+                    case ReconnectionStatus.Off:
+                        if(heartbeatReceived > ReconnectTimeout)
+                        {
+                            previousRoomGUID = new Guid(room.UUID);
+                            ResetAndReconnect();
+                            lastResetTime = Time.realtimeSinceStartup;
+                            reconnectionStatus = ReconnectionStatus.Reset;
+                        }
+                        break;
+                    // Reconnection Reset: Connection is reset. While no response has been received, reset connection again in regular intervals.
+                    case ReconnectionStatus.Reset:
+                        if (timeSinceLastReset > ReconnectInterval)
+                        {
+                            ResetAndReconnect();
+                            lastResetTime = Time.realtimeSinceStartup;                            
+                        }
+                        break;
+                    // Reconnection Received: A response by Nexus has received. Attempt at rejoining room.
+                    case ReconnectionStatus.Received:
+                        Join(previousRoomGUID);
+                        lastRejoinTime = Time.realtimeSinceStartup;
+                        reconnectionStatus = ReconnectionStatus.Rejoining;
+                        break;
+                    // Reconnection Rejoining: Re-attempt rejoining room at regular intervals until succesful.
+                    case ReconnectionStatus.Rejoining:
+                        if(room.UUID == previousRoomGUID.ToString())
+                        {
+                            reconnectionStatus = ReconnectionStatus.Off;
+                        }
+                        else if(timeSinceLastRejoin > RejoinInterval)
+                        {
+                            Join(previousRoomGUID);
+                            lastRejoinTime = Time.realtimeSinceStartup;
+                        }
+                        break;
                 }
             }
         }

--- a/Unity/Assets/Samples/Start Here.unity
+++ b/Unity/Assets/Samples/Start Here.unity
@@ -413,6 +413,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -461,6 +462,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -1.214, y: 0.634, z: -0.99}
   m_LocalScale: {x: 0.25361246, y: 0.25361246, z: 0.25361246}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4
@@ -706,6 +708,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2642065778884258271, guid: 46c1f5d5a11cf5042886aabd56e7b9d7,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2642065778884258271, guid: 46c1f5d5a11cf5042886aabd56e7b9d7,
         type: 3}

--- a/Unity/Assets/Samples/_Common/Prefabs/Network Scene.prefab
+++ b/Unity/Assets/Samples/_Common/Prefabs/Network Scene.prefab
@@ -27,6 +27,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7068762446378101729}
   m_RootOrder: 4
@@ -72,6 +73,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7068762446378101729}
   m_RootOrder: 0
@@ -118,6 +120,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7068762446051028576}
   - {fileID: 7068762446560339092}
@@ -160,6 +163,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   servers:
   - {fileID: -7849211376014683480, guid: 1c91df7c43c1dbe4fb0fb303e71a2790, type: 2}
+  reconnectBehaviour: 2
 --- !u!114 &7068762446378101731
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -217,6 +221,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7068762446378101729}
   m_RootOrder: 1
@@ -260,6 +265,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7068762446378101729}
   m_RootOrder: 2
@@ -309,6 +315,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7068762446378101729}
   m_RootOrder: 3


### PR DESCRIPTION
Adding an automatic reconnection process to RoomClient for recovery after the connection to Nexus is lost. On connection loss, the room client instructs the scene to drop all connections and then periodically attempts to reconnect them until a succesful ping response is received again. Once the connection to Nexus is re-established, the RoomClient then periodically attempts to rejoin the Room the client was in at time of the connection loss until it can join succesfully.